### PR TITLE
Fix typings for Flow 0.55

### DIFF
--- a/src/schema.js
+++ b/src/schema.js
@@ -387,7 +387,7 @@ export function enumeration(...values: Array<mixed>) {
   return node;
 }
 
-export class OneOfNode<A> extends Node<A> {
+export class OneOfNode<V> extends Node<V> {
 
   nodes: Array<Node<*>>;
 

--- a/src/schema.js
+++ b/src/schema.js
@@ -387,7 +387,7 @@ export function enumeration(...values: Array<mixed>) {
   return node;
 }
 
-export class OneOfNode extends Node {
+export class OneOfNode<A> extends Node<A> {
 
   nodes: Array<Node<*>>;
 


### PR DESCRIPTION
At some point Flow has required that type parameters be annotated, instead of left in "point-free" form.

Fixes the following error message on flow 0.55.0:

```
Error: src/schema.js:390
390: export class OneOfNode extends Node {
                                    ^^^^ polymorphic type: class type: Node. Too few type arguments. Expected at least 1
128: export class Node<V> {
                       ^ See type parameters of definition here


Found 1 error
```